### PR TITLE
Fix editing

### DIFF
--- a/pages/edit.tsx
+++ b/pages/edit.tsx
@@ -108,11 +108,13 @@ function Form({ space }: { space: string }) {
   const methods = useForm<ProposalFormValues>();
   const { register, handleSubmit, control, formState: { errors } } = methods;
   const onSubmit: SubmitHandler<ProposalFormValues> = async (formData) => {
+    const { body, title, payout, ...restOfProposal } = metadata?.loadedProposal ?? { }; // send back all values except ones in form
     const payload = {
       ...formData.proposal,
       body: await htmlToMarkdown(formData.proposal.body),
       type: "Payout",
-      version: String(metadata.version)
+      version: String(metadata.version),
+      ...restOfProposal
     };
     console.debug("📚 Nance.editProposal.onSubmit ->", { formData, payload })
 

--- a/pages/p/[proposal].tsx
+++ b/pages/p/[proposal].tsx
@@ -101,7 +101,7 @@ export default function NanceProposalPage({ proposal, snapshotProposal }: { prop
     const commonProps: ProposalCommonProps = {
         status: snapshotProposal?.state || proposal.status,
         title: snapshotProposal?.title || proposal.title,
-        author: snapshotProposal?.author || proposal.author,
+        author: snapshotProposal?.author || proposal.authorAddress,
         body: snapshotProposal?.body || proposal.body,
         created: snapshotProposal?.start || Math.floor(new Date(proposal.date).getTime() / 1000),
         end: snapshotProposal?.end || 0


### PR DESCRIPTION
Need to send proposal hash (uuid) back to nance-api in order to properly update the proposal otherwise there is no one of knowing which proposal one is editing

Other minor fix:
use `proposal.authorAddress` instead of `proposal.author` when showing who wrote (sorry for the bad naming @twodam!)