### PR TITLE
feature: create nance instance

### DIFF
--- a/hooks/NanceHooks.ts
+++ b/hooks/NanceHooks.ts
@@ -11,7 +11,9 @@ import {
     SpaceInfo,
     Proposal,
     FetchReconfigureData,
-    ProposalUploadPayload
+    ProposalUploadPayload,
+    ConfigSpaceRequest,
+    ConfigSpacePayload,
 } from '../models/NanceTypes';
 
 function jsonFetcher(): Fetcher<APIResponse<any>, string> {
@@ -81,6 +83,22 @@ async function uploader(url: RequestInfo | URL, { arg }: { arg: ProposalUploadRe
     return json
 }
 
+async function creator(url: RequestInfo | URL, { arg }: { arg: ConfigSpaceRequest }) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(arg)
+    })
+    const json: APIResponse<ConfigSpacePayload> = await res.json()
+    if (json.success === false) {
+        throw new Error(`An error occurred while uploading the data: ${json?.error}`)
+    }
+
+    return json
+}
+
 export function useProposalUpload(space: string, proposalId: string, shouldFetch: boolean = true) {
     let url = `${NANCE_API_URL}/${space}/proposals`
     let fetcher = uploader
@@ -88,6 +106,15 @@ export function useProposalUpload(space: string, proposalId: string, shouldFetch
         url = `${NANCE_API_URL}/${space}/proposal/${proposalId}`
         fetcher = editor
     }
+    return useSWRMutation(
+        shouldFetch ? url : null,
+        fetcher,
+    );
+}
+
+export function useCreateSpace(space: string, shouldFetch: boolean = true) {
+    const url = `${NANCE_API_URL}/nanceish/config`
+    let fetcher = creator
     return useSWRMutation(
         shouldFetch ? url : null,
         fetcher,

--- a/hooks/NanceHooks.ts
+++ b/hooks/NanceHooks.ts
@@ -112,8 +112,8 @@ export function useProposalUpload(space: string, proposalId: string, shouldFetch
     );
 }
 
-export function useCreateSpace(space: string, shouldFetch: boolean = true) {
-    const url = `${NANCE_API_URL}/nanceish/config`
+export function useCreateSpace(shouldFetch: boolean = true) {
+    const url = `${NANCE_API_URL}/ish/config`
     let fetcher = creator
     return useSWRMutation(
         shouldFetch ? url : null,

--- a/models/NanceTypes.ts
+++ b/models/NanceTypes.ts
@@ -85,6 +85,7 @@ export interface ConfigSpaceRequest extends SignatureRequest {
 export type CreateFormValues = {
   name: string;
   discord: DiscordConfig;
+  propertyKeys: Partial<PropertyKeys>;
   juicebox: JuiceboxConfig;
   snapshot: SnapshotConfig;
 }
@@ -114,7 +115,7 @@ export type SnapshotConfig = {
   passingRatio: number;
 }
 
-export type CreateFormKeys = 'name' |
+export type CreateFormKeys = 'name' | 'propertyKeys.proposalIdPrefix' |
   `discord.${keyof DiscordConfig}` |
   `discord.channelIds.${keyof DiscordConfigChannels}`|
   `discord.roleIds.${keyof DiscordConfigRoles}` |
@@ -123,6 +124,7 @@ export type CreateFormKeys = 'name' |
 
 export type ConfigSpacePayload = {
   space: string;
+  spaceOwner: string;
 }
 
 // from https://github.com/jigglyjams/nance-ts/blob/main/src/types.ts
@@ -216,31 +218,23 @@ export type ProposalNoHash = Omit<Proposal, 'hash'>;
 export type ProposalStore = Record<string, ProposalNoHash>;
 
 export interface NanceConfig {
-  nameId: string;
   name: string;
-  calendarPath: string;
-  scheme: string[];
-  proposalDataBackup: string;
-  ipfsGateway: string;
-  votingResultsDashboard: string;
-  translation: {
-    api: string;
-    targetLanguage: any;
-    storage: {
-      user: string;
-      repo: string;
-    }
-  };
   juicebox: {
-    network: 'mainnet' | 'rinkeby';
+    network: string;
     projectId: string;
     gnosisSafeAddress: string;
   };
   discord: {
     API_KEY: string;
     guildId: string;
-    channelId: string;
-    alertRole: string;
+    roles: {
+      governance: string;
+    };
+    channelIds: {
+      proposals: string;
+      bookkeeping: string;
+      transactions: string;
+    }
     poll: {
       voteYesEmoji: string;
       voteNoEmoji: string;
@@ -251,62 +245,23 @@ export interface NanceConfig {
       yesNoRatio: number;
       showResults: boolean;
     };
+    reminder: {
+      channelIds: string[];
+      imagesCID: string;
+      imageNames: string[];
+      links: Record<string, string>;
+    };
   };
+  propertyKeys: PropertyKeys;
   notion: {
     API_KEY: string;
-    publicURLPrefix: string;
+    enabled: boolean;
     database_id: string;
+    current_cycle_block_id: string;
     payouts_database_id: string;
     reserves_database_id: string;
-    propertyKeys: {
-      proposalId: string;
-      status: string;
-      statusTemperatureCheck: string;
-      statusVoting: string;
-      statusApproved: string;
-      statusCancelled: string;
-      proposalIdPrefix: string;
-      discussionThread: string;
-      ipfs: string;
-      vote: string;
-      category: string;
-      categoryRecurringPayout: string;
-      categoryPayout: string;
-      governanceCycle: string;
-      governanceCyclePrefix: string;
-      reservePercentage: string;
-      payoutName: string;
-      payoutType: string;
-      payoutAmountUSD: string;
-      payoutAddress: string;
-      payoutCount: string;
-      treasuryVersion: string;
-      payoutFirstFC: string;
-      payoutLastFC: string;
-      payoutRenewalFC: string;
-      payoutProposalLink: string;
-    };
-    filters: any;
   };
-  github: {
-    user: string;
-    repo: string;
-    propertyKeys: {
-      title: string;
-      proposalId: string;
-      status: string;
-      statusTemperatureCheck: string;
-      statusVoting: string;
-      statusApproved: string;
-      statusCancelled: string;
-      proposalIdPrefix: string;
-      discussionThread: string;
-      ipfs: string;
-      vote: string;
-      category: string;
-      governanceCycle: string;
-    },
-  },
+  dolt: DoltConfig,
   snapshot: {
     base: string;
     space: string;
@@ -314,7 +269,45 @@ export interface NanceConfig {
     minTokenPassingAmount: number;
     passingRatio: number;
   };
+  calendarCID?: string;
 }
+
+export type DoltConfig = {
+  enabled: boolean;
+  owner: string;
+  repo: string;
+};
+
+export type PropertyKeys = {
+  proposalId: string;
+  status: string;
+  statusTemperatureCheck: string;
+  statusVoting: string;
+  statusApproved: string;
+  statusCancelled: string;
+  proposalIdPrefix: string;
+  discussionThread: string;
+  ipfs: string;
+  vote: string;
+  type: string;
+  typeRecurringPayout: string;
+  typePayout: string;
+  governanceCycle: string;
+  governanceCyclePrefix: string;
+  reservePercentage: string;
+  payoutName: string;
+  payoutType: string;
+  payoutAmountUSD: string;
+  payoutAddress: string;
+  payoutCount: string;
+  payName: string;
+  treasuryVersion: string;
+  payoutFirstFC: string;
+  payoutLastFC: string;
+  payoutRenewalFC: string;
+  payoutProposalLink: string;
+  publicURLPrefix: string;
+};
 
 export interface DateEvent {
   title: string;

--- a/models/NanceTypes.ts
+++ b/models/NanceTypes.ts
@@ -77,6 +77,35 @@ export interface ProposalUploadRequest extends SignatureRequest {
     "notification">;
 }
 
+export interface ConfigSpaceRequest extends SignatureRequest {
+  config: CreateFormValues;
+  calendar?: string;
+}
+
+export type CreateFormValues = {
+  name: string;
+  discord: {
+    guildId: string;
+    roles: { governance: string; };
+    channelIds: {
+      proposals: string;
+    }
+  };
+  juicebox: {
+    projectId: string;
+    gnosisSafeAddress: string;
+  };
+  snapshot: {
+    space: string;
+    minTokenPassingAmount: number;
+    passingRatio: number;
+  };
+}
+
+export type ConfigSpacePayload = {
+  space: string;
+}
+
 // from https://github.com/jigglyjams/nance-ts/blob/main/src/types.ts
 type ProposalType = 'Payout' | 'ReservedToken' | 'ParameterUpdate' | 'ProcessUpdate' | 'CustomTransaction';
 

--- a/models/NanceTypes.ts
+++ b/models/NanceTypes.ts
@@ -84,23 +84,42 @@ export interface ConfigSpaceRequest extends SignatureRequest {
 
 export type CreateFormValues = {
   name: string;
-  discord: {
-    guildId: string;
-    roles: { governance: string; };
-    channelIds: {
-      proposals: string;
-    }
-  };
-  juicebox: {
-    projectId: string;
-    gnosisSafeAddress: string;
-  };
-  snapshot: {
-    space: string;
-    minTokenPassingAmount: number;
-    passingRatio: number;
-  };
+  discord: DiscordConfig;
+  juicebox: JuiceboxConfig;
+  snapshot: SnapshotConfig;
 }
+
+export type DiscordConfig = {
+  guildId: string;
+  roleIds: DiscordConfigRoles;
+  channelIds: DiscordConfigChannels;
+}
+
+export type DiscordConfigChannels = {
+  proposals: string;
+}
+
+export type DiscordConfigRoles = {
+  governance: string;
+}
+
+export type JuiceboxConfig = {
+  projectId: string;
+  gnosisSafeAddress: string;
+}
+
+export type SnapshotConfig = {
+  space: string;
+  minTokenPassingAmount: number;
+  passingRatio: number;
+}
+
+export type CreateFormKeys = 'name' |
+  `discord.${keyof DiscordConfig}` |
+  `discord.channelIds.${keyof DiscordConfigChannels}`|
+  `discord.roleIds.${keyof DiscordConfigRoles}` |
+  `snapshot.${keyof SnapshotConfig}` |
+  `juicebox.${keyof JuiceboxConfig}`
 
 export type ConfigSpacePayload = {
   space: string;

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -1,0 +1,88 @@
+import { useContext, useEffect, useState } from "react";
+import SiteNav from "../components/SiteNav";
+import { useForm, FormProvider, useFormContext, Controller, SubmitHandler } from "react-hook-form";
+import { useRouter } from "next/router";
+import { useAccount, useSigner } from "wagmi";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { JsonRpcSigner } from "@ethersproject/providers";
+import { signPayload } from "../libs/signer";
+import { CreateFormValues } from "../models/NanceTypes";
+import { useCreateSpace } from "../hooks/NanceHooks";
+
+
+export default function TreasuryPage() {
+  return (
+    <>
+      <SiteNav pageTitle='nance control panel' />
+      
+      <div className="m-12">
+        <div className="flex justify-between">
+          <h1 className="text-lg font-bold leading-6 text-gray-900">Create New nance Instance</h1>
+
+        </div>
+      </div>
+    </>
+  );
+}
+
+function Form({ space }: { space: string }) {
+  // query and context
+  const router = useRouter();
+
+  // state
+  const [signing, setSigning] = useState(false);
+  const [signError, setSignError] = useState(undefined);
+
+  // hooks
+  const { isMutating, error: uploadError, trigger, data, reset } = useCreateSpace(space as string, router.isReady);
+  const { data: signer, isError, isLoading } = useSigner()
+  const jrpcSigner = signer as JsonRpcSigner;
+  const { address, isConnected } = useAccount();
+  const { openConnectModal } = useConnectModal();
+
+  // form
+  const methods = useForm<CreateFormValues>();
+  const { register, handleSubmit, control, formState: { errors } } = methods;
+  const onSubmit: SubmitHandler<CreateFormValues> = async (formData) => {
+    const payload = { };
+    console.debug("📚 Nance.createSpace.onSubmit ->", { formData, payload })
+
+    setSigning(true);
+
+    signPayload(
+      jrpcSigner, space as string,
+      "config",
+      payload
+    ).then((signature) => {
+
+      setSigning(false);
+      // send to API endpoint
+      reset();
+      const req = {
+        signature,
+        config: formData
+      }
+      console.debug("📗 Nance.createSpace.submit ->", req);
+      return trigger(req);
+    })
+      .then(res => router.push(`/overrideSpace=${res.data}`))
+      .catch((err) => {
+        setSigning(false);
+        setSignError(err);
+        console.warn("📗 Nance.editProposal.onSignError ->", err);
+      });
+  }
+
+  // shortcut
+  const isSubmitting = signing || isMutating;
+  const error = signError || uploadError;
+  const resetSignAndUpload = () => {
+    setSignError(undefined);
+    reset();
+  }
+
+  return (
+    <FormProvider {...methods} >
+    </FormProvider>
+  )
+}

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -1,40 +1,50 @@
-import { useContext, useEffect, useState } from "react";
+import { useState } from "react";
 import SiteNav from "../components/SiteNav";
-import { useForm, FormProvider, useFormContext, Controller, SubmitHandler } from "react-hook-form";
+import { useForm, FormProvider, SubmitHandler } from "react-hook-form";
 import { useRouter } from "next/router";
 import { useAccount, useSigner } from "wagmi";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { JsonRpcSigner } from "@ethersproject/providers";
 import { signPayload } from "../libs/signer";
-import { CreateFormValues } from "../models/NanceTypes";
+import { CreateFormValues, CreateFormKeys } from "../models/NanceTypes";
 import { useCreateSpace } from "../hooks/NanceHooks";
 
+type TextInputProps = {
+  label: string;
+  name: CreateFormKeys;
+  register: any;
+  placeholder: string;
+  required: boolean;
+  defaultValue: string | number;
+  type: string;
+}
 
-export default function TreasuryPage() {
+export default function CreateSpacePage() {
   return (
     <>
-      <SiteNav pageTitle='nance control panel' />
+      <SiteNav pageTitle='nance control panel' withWallet/>
       
       <div className="m-12">
-        <div className="flex justify-between">
+        <div className="w-64 justify-left">
           <h1 className="text-lg font-bold leading-6 text-gray-900">Create New nance Instance</h1>
-
+          <Form />
         </div>
       </div>
     </>
   );
 }
 
-function Form({ space }: { space: string }) {
+function Form() {
   // query and context
   const router = useRouter();
 
   // state
   const [signing, setSigning] = useState(false);
   const [signError, setSignError] = useState(undefined);
+  const [spaceConfig, setSpaceConfig] = useState<CreateFormValues>(undefined);
 
   // hooks
-  const { isMutating, error: uploadError, trigger, data, reset } = useCreateSpace(space as string, router.isReady);
+  const { isMutating, error: uploadError, trigger, data, reset } = useCreateSpace(spaceConfig?.name as string, router.isReady);
   const { data: signer, isError, isLoading } = useSigner()
   const jrpcSigner = signer as JsonRpcSigner;
   const { address, isConnected } = useAccount();
@@ -44,17 +54,13 @@ function Form({ space }: { space: string }) {
   const methods = useForm<CreateFormValues>();
   const { register, handleSubmit, control, formState: { errors } } = methods;
   const onSubmit: SubmitHandler<CreateFormValues> = async (formData) => {
+    console.log(formData);
     const payload = { };
     console.debug("📚 Nance.createSpace.onSubmit ->", { formData, payload })
 
     setSigning(true);
 
-    signPayload(
-      jrpcSigner, space as string,
-      "config",
-      payload
-    ).then((signature) => {
-
+    signPayload(jrpcSigner, "nanceish", "config", payload).then((signature) => {
       setSigning(false);
       // send to API endpoint
       reset();
@@ -83,6 +89,35 @@ function Form({ space }: { space: string }) {
 
   return (
     <FormProvider {...methods} >
+      <form className="m-4 lg:m-6 flex flex-col" onSubmit={handleSubmit(onSubmit)}>
+        <FormInput label="Nance space name" name="name" register={register} />
+        <FormInput label="Discord Guild ID #" name="discord.guildId" register={register} />
+        <FormInput label="Discord Alert Role ID #" name="discord.roleIds.governance" register={register} />
+        <FormInput label="Proposal Channel ID #" name="discord.channelIds.proposals" register={register} />
+        <FormInput label="Snapshot space key" name="snapshot.space" register={register} />
+        <FormInput label="Snapshot minimum passing token amount" name="snapshot.minTokenPassingAmount" register={register} type="number" defaultValue={80E6} />
+        <button type="submit"
+          className="ml-3 inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium
+          text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:bg-gray-400">
+          Submit
+        </button>
+      </form>
     </FormProvider>
   )
+}
+
+const FormInput = ({ label, name, defaultValue, register, required = true, type = "text" }: Partial<TextInputProps>) => {
+  return (
+    <div className="flex flex-col mb-4 w-80">
+      <label htmlFor={name} className="block text-sm font-medium text-gray-700">{label}</label>
+      <input
+        type={type}
+        id={name}
+        name={name}
+        defaultValue={defaultValue}
+        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+        {...register(name, { required, shouldUnregister: true })}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## What does this PR do and why?

_Provide a description of what this PR does. Link to any relevant GitHub issues, Notion tasks or Discord discussions._

This adds a `/create` page that allows for a user to create a new nance instance. Its a very basic form for now that should be improved upon later.

When the user signs a message to create a nance instance, the backend creates a new database to hold all of the spaces proposals, payouts, reserve rates, and governance cycle status. See https://github.com/nance-eth/nance-ts/blob/1d62782f9399d6df271ce842532ce4c114874fc1/src/api/nanceish.ts#L17 for more details.

## Screenshots or screen recordings

_If applicable, provide screenshots or screen recordings to demonstrate the changes._

<img width="909" alt="image" src="https://user-images.githubusercontent.com/83923290/230907156-d2523cf0-5a14-45ff-9528-83f263f6923f.png">
