### PR TITLE
feature: delete proposal and set status on new proposal

### DIFF
--- a/constants/Nance.ts
+++ b/constants/Nance.ts
@@ -2,3 +2,10 @@ export const NANCE_API_URL = process.env.NEXT_PUBLIC_NANCE_API_URL || "https://a
 export const NANCE_DEFAULT_SPACE = process.env.NEXT_PUBLIC_OVERRIDE_SPACE || "juicebox";
 export const NANCE_DEFAULT_JUICEBOX_PROJECT: number = 1;
 export const NANCE_DEFAULT_IPFS_GATEWAY = 'https://nance.infura-ipfs.io';
+
+export const proposalSetStatuses = {
+  0: "Discussion",
+  1: "Draft",
+  2: "Revoked",
+  3: "Archived",
+};

--- a/hooks/NanceHooks.ts
+++ b/hooks/NanceHooks.ts
@@ -11,7 +11,8 @@ import {
     SpaceInfo,
     Proposal,
     FetchReconfigureData,
-    ProposalUploadPayload
+    ProposalUploadPayload,
+    ProposalDeleteRequest,
 } from '../models/NanceTypes';
 
 function jsonFetcher(): Fetcher<APIResponse<any>, string> {
@@ -101,6 +102,15 @@ export function useProposalUpload(space: string, proposalId: string, shouldFetch
     );
 }
 
+export function useProposalDelete(space: string, uuid: string, shouldFetch: boolean = true) {
+    let url = `${NANCE_API_URL}/${space}/proposal/${uuid}`
+    let fetcher = deleter
+    return useSWRMutation(
+        shouldFetch ? url : null,
+        fetcher,
+    );
+}
+
 async function editor(url: RequestInfo | URL, { arg }: { arg: ProposalUploadRequest }) {
     const res = await fetch(url, {
       method: 'PUT',
@@ -112,6 +122,22 @@ async function editor(url: RequestInfo | URL, { arg }: { arg: ProposalUploadRequ
     const json: APIResponse<ProposalUploadPayload> = await res.json()
     if (json.success === false) {
         throw new Error(`An error occurred while uploading the data: ${json?.error}`)
+    }
+
+    return json
+}
+
+async function deleter(url: RequestInfo | URL, { arg }: { arg: ProposalDeleteRequest }) {
+    const res = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(arg)
+    })
+    const json: APIResponse<ProposalUploadPayload> = await res.json()
+    if (json.success === false) {
+        throw new Error(`An error occurred while deleting this proposal: ${json?.error}`)
     }
 
     return json

--- a/libs/nance.ts
+++ b/libs/nance.ts
@@ -20,9 +20,10 @@ export function urlOfContent(space: string, hash: string) {
 }
 
 export function canEditProposal(status: string) {
-    return (
-        status === 'Discussion' ||
-        status === 'Draft' ||
-        status === 'Temperature Check'
-    );
+    return ([
+        'Discussion',
+        'Draft',
+        'Temperature Check',
+        undefined,
+    ].includes(status));
 };

--- a/libs/nance.ts
+++ b/libs/nance.ts
@@ -18,3 +18,11 @@ export function urlOfQuery(space: string, cycle: number | undefined) {
 export function urlOfContent(space: string, hash: string) {
     return `${NANCE_API_URL}/${space}/markdown?hash=${hash}`;
 }
+
+export function canEditProposal(status: string) {
+    return (
+        status === 'Discussion' ||
+        status === 'Draft' ||
+        status === 'Temperature Check'
+    );
+};

--- a/models/NanceTypes.ts
+++ b/models/NanceTypes.ts
@@ -78,6 +78,10 @@ export interface ProposalUploadRequest extends SignatureRequest {
   proposal: Pick<Proposal, "title" | "body" | "notification" | "actions">;
 }
 
+export interface ProposalDeleteRequest extends SignatureRequest {
+  hash: string;
+}
+
 // from https://github.com/jigglyjams/nance-ts/blob/main/src/types.ts
 type ProposalType = 'Payout' | 'ReservedToken' | 'ParameterUpdate' | 'ProcessUpdate' | 'CustomTransaction';
 

--- a/models/NanceTypes.ts
+++ b/models/NanceTypes.ts
@@ -75,7 +75,7 @@ export interface SignatureRequest {
 export interface ProposalUploadRequest extends SignatureRequest {
   // presented when editting proposal
   hash?: string
-  proposal: Pick<Proposal, "title" | "body" | "notification" | "actions">;
+  proposal: Pick<Proposal, "title" | "body" | "notification" | "actions" | "status">;
 }
 
 export interface ProposalDeleteRequest extends SignatureRequest {

--- a/pages/s/[space]/[proposal].tsx
+++ b/pages/s/[space]/[proposal].tsx
@@ -213,7 +213,7 @@ export default function NanceProposalPage({ space, proposal, snapshotProposal }:
                           </a>
                         </>
                       )}
-                      {(proposal.status === "Temperature Check" || proposal.status === "Discussion") && (
+                      {(proposal.status === "Temperature Check" || proposal.status === "Discussion" || proposal.status === "Draft") && (
                         <>
                           <Link
                             legacyBehavior

--- a/pages/s/[space]/[proposal].tsx
+++ b/pages/s/[space]/[proposal].tsx
@@ -14,7 +14,7 @@ import rehypeRaw from 'rehype-raw';
 import rehypeSanitize from 'rehype-sanitize';
 import ColorBar from "../../../components/ColorBar";
 import { fetchProposal, useProposal } from "../../../hooks/NanceHooks";
-import { getLastSlash } from "../../../libs/nance";
+import { canEditProposal, getLastSlash } from "../../../libs/nance";
 import { Proposal, Payout, Action, Transfer, CustomTransaction, Reserve } from "../../../models/NanceTypes";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import Link from "next/link";
@@ -213,7 +213,7 @@ export default function NanceProposalPage({ space, proposal, snapshotProposal }:
                           </a>
                         </>
                       )}
-                      {(proposal.status === "Temperature Check" || proposal.status === "Discussion" || proposal.status === "Draft") && (
+                      {canEditProposal(proposal.status) && (
                         <>
                           <Link
                             legacyBehavior

--- a/pages/s/[space]/edit.tsx
+++ b/pages/s/[space]/edit.tsx
@@ -10,7 +10,7 @@ import { fetchProposal, useProposalDelete, useProposalUpload } from "../../../ho
 import { imageUpload } from "../../../hooks/ImageUpload";
 import { fileDrop } from "../../../hooks/FileDrop";
 import { Proposal, ProposalUploadRequest, ProposalDeleteRequest, Action, JBSplitNanceStruct } from "../../../models/NanceTypes";
-import { NANCE_DEFAULT_JUICEBOX_PROJECT, NANCE_DEFAULT_SPACE } from "../../../constants/Nance";
+import { NANCE_DEFAULT_JUICEBOX_PROJECT, NANCE_DEFAULT_SPACE, proposalSetStatuses } from "../../../constants/Nance";
 import Link from "next/link";
 
 import { useSigner } from "wagmi";
@@ -264,15 +264,22 @@ function Form({ space }: { space: string }) {
                     }
                   />
                 </div>
-
               </div>
             </div>
           </div>
 
           <p className="text-gray-500 text-sm mt-1">
             <CheckCircleIcon className="h-5 w-5 inline mr-1" />
-            Drag and drop markdown file or image to attach content
+            Drag and drop markdown file or image to attach content (images are pinned to IPFS)
           </p>
+          <p className="text-gray-500 text-sm mt-5 mb-1">set status</p>
+          <div className="flex items-center">
+            <select {...register("proposal.status")} className="block rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">
+              {Object.entries(proposalSetStatuses).map(([key, val]) => (
+                <option key={key}>{val}</option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {formErrors.length > 0 && (
@@ -300,7 +307,7 @@ function Form({ space }: { space: string }) {
 
           {jrpcSigner &&
           ((metadata.loadedProposal?.status === 'Discussion') ||
-          (metadata.loadedProposal?.status == 'Draft'))
+          (metadata.loadedProposal?.status === 'Draft'))
           && (
             <button type="button"
               className="ml-3 inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:bg-gray-400"

--- a/pages/s/[space]/edit.tsx
+++ b/pages/s/[space]/edit.tsx
@@ -308,7 +308,7 @@ function Form({ space }: { space: string }) {
             </button>
           )}
 
-          {jrpcSigner && canEditProposal(metadata.loadedProposal?.status) && (
+          {jrpcSigner && canEditProposal(metadata.loadedProposal?.status) && !isNew &&(
             <button type="button"
               className="ml-3 inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:bg-gray-400"
               onClick={deleteProposal}

--- a/pages/s/[space]/edit.tsx
+++ b/pages/s/[space]/edit.tsx
@@ -11,6 +11,7 @@ import { imageUpload } from "../../../hooks/ImageUpload";
 import { fileDrop } from "../../../hooks/FileDrop";
 import { Proposal, ProposalUploadRequest, ProposalDeleteRequest, Action, JBSplitNanceStruct } from "../../../models/NanceTypes";
 import { NANCE_DEFAULT_JUICEBOX_PROJECT, NANCE_DEFAULT_SPACE, proposalSetStatuses } from "../../../constants/Nance";
+import { canEditProposal } from "../../../libs/nance";
 import Link from "next/link";
 
 import { useSigner } from "wagmi";
@@ -272,14 +273,16 @@ function Form({ space }: { space: string }) {
             <CheckCircleIcon className="h-5 w-5 inline mr-1" />
             Drag and drop markdown file or image to attach content (images are pinned to IPFS)
           </p>
-          <p className="text-gray-500 text-sm mt-5 mb-1">set status</p>
-          <div className="flex items-center">
-            <select {...register("proposal.status")} className="block rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">
-              {Object.entries(proposalSetStatuses).map(([key, val]) => (
-                <option key={key}>{val}</option>
-              ))}
-            </select>
-          </div>
+          {canEditProposal(metadata.loadedProposal?.status) && (
+            <div>
+              <p className="text-gray-500 text-sm mt-5 mb-1">set status</p>
+              <select {...register("proposal.status")} className="block rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500">
+                {Object.entries(proposalSetStatuses).map(([key, val]) => (
+                  <option key={key}>{val}</option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
 
         {formErrors.length > 0 && (
@@ -305,10 +308,7 @@ function Form({ space }: { space: string }) {
             </button>
           )}
 
-          {jrpcSigner &&
-          ((metadata.loadedProposal?.status === 'Discussion') ||
-          (metadata.loadedProposal?.status === 'Draft'))
-          && (
+          {jrpcSigner && canEditProposal(metadata.loadedProposal?.status) && (
             <button type="button"
               className="ml-3 inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:bg-gray-400"
               onClick={deleteProposal}


### PR DESCRIPTION
This PR updates the edit proposal page and adds:
* Delete button
* Status setting select drop down
if the proposal is in Draft, Discussion, or Temperature Check

<img width="1197" alt="image" src="https://github.com/nance-eth/nance-interface/assets/83923290/f6b3e03a-b443-42a7-a915-af69ff296d75">

nance-api only gives a proposal a proposalId and starts a thread if it is submitted as Discussion. If submitted as Draft and updated to Discussion it will assign a proposalId and start a Discord thread

nance-api only allows for the author, multisig owner, or spaceOwner to delete a proposal
https://github.com/nance-eth/nance-ts/blob/81e66b59c77cf4b91dc3ecf23390a19e657a811d/src/api/api.ts#LL214C13-L214C13

